### PR TITLE
Add CLI command

### DIFF
--- a/.ci/tests/basic.bats
+++ b/.ci/tests/basic.bats
@@ -38,6 +38,14 @@ inspect_volume() {
   $TERMINUSDB_QUICKSTART_DOCKER volume inspect -f '{{.Name}}' "${TERMINUSDB_QUICKSTART_STORAGE}"
 }
 
+
+@test "quickstart cli" {
+  run container run
+  run container cli
+  [[ "${status}" == 0 ]]
+  run container stop
+}
+
 @test "quickstart run" {
   run container run
   [[ "${status}" == 0 ]]
@@ -53,13 +61,6 @@ inspect_volume() {
 @test "quickstart help" {
   run container help
   [[ "${status}" == 0 ]]
-}
-
-@test "quickstart cli" {
-  run container run
-  run container cli
-  [[ "${status}" == 0 ]]
-  run container stop
 }
 
 @test "quickstart attach" {

--- a/.ci/tests/basic.bats
+++ b/.ci/tests/basic.bats
@@ -56,8 +56,10 @@ inspect_volume() {
 }
 
 @test "quickstart cli" {
+  run container run
   run container cli
   [[ "${status}" == 0 ]]
+  run container stop
 }
 
 @test "quickstart attach" {

--- a/.ci/tests/basic.bats
+++ b/.ci/tests/basic.bats
@@ -58,10 +58,6 @@ inspect_volume() {
 @test "quickstart cli" {
   run container cli
   [[ "${status}" == 0 ]]
-  run container cli --help
-  [[ "${status}" == 0 ]]
-  run container cli doc get _system
-  [[ "${status}" == 0 ]]
 }
 
 @test "quickstart attach" {

--- a/.ci/tests/basic.bats
+++ b/.ci/tests/basic.bats
@@ -55,6 +55,15 @@ inspect_volume() {
   [[ "${status}" == 0 ]]
 }
 
+@test "quickstart cli" {
+  run container cli
+  [[ "${status}" == 0 ]]
+  run container cli --help
+  [[ "${status}" == 0 ]]
+  run container cli doc get _system
+  [[ "${status}" == 0 ]]
+}
+
 @test "quickstart attach" {
   command -v expect || skip
   run expect "${BATS_TEST_DIRNAME}/expect/attach.exp"

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ USAGE:
 
   help        show usage
   run         run container
+  cli         use the terminusdb cli
   stop        stop container
   attach      attach to prolog shell
   exec        execute a command inside the container

--- a/terminusdb-container
+++ b/terminusdb-container
@@ -135,6 +135,7 @@ USAGE:
 
   help        show usage
   run         run container
+  cli         use the terminusdb cli
   stop        stop container
   attach      attach to prolog shell
   exec        execeute a command inside the container
@@ -179,6 +180,13 @@ _run () {
     "-e TERMINUSDB_AUTOLOGIN_ENABLED=\"$TERMINUSDB_QUICKSTART_AUTOLOGIN\"" \
     "-e TERMINUSDB_JWT_ENABLED=\"$TERMINUSDB_QUICKSTART_JWT_ENABLED\"" \
     "$TERMINUSDB_QUICKSTART_REPOSITORY:$TERMINUSDB_QUICKSTART_TAG"
+}
+
+_cli () {
+    eval "$TERMINUSDB_QUICKSTART_DOCKER" exec -it \
+      "$TERMINUSDB_QUICKSTART_CONTAINER" \
+      "./terminusdb" \
+      "$TERMINUSDB_RUN_CMD"
 }
 
 _stop () {
@@ -238,6 +246,14 @@ if [[ -n "$1" ]]; then
       _run > /dev/null \
         && printf "terminusdb-server container started %s\n" "$TERMINUSDB_URL" \
         || printf "\nIs the container already running?\n"
+    ;;
+    "cli")
+       _check_if_docker_is_in_path
+      if [[ -n "$2" ]]; then
+        # shellcheck disable=SC2124
+        TERMINUSDB_RUN_CMD="${@:2}"
+      fi
+        _cli
     ;;
     "stop")
       _check_if_docker_is_in_path

--- a/terminusdb-container
+++ b/terminusdb-container
@@ -253,7 +253,7 @@ if [[ -n "$1" ]]; then
         # shellcheck disable=SC2124
         TERMINUSDB_RUN_CMD="${@:2}"
       fi
-        _cli
+        _cli || printf "\nError on executing the CLI command, did you forget to run the container first with the run command?"
     ;;
     "stop")
       _check_if_docker_is_in_path


### PR DESCRIPTION
Add a CLI command to make it easier to use terminusdb's CLIs with the `terminusdb-bootstrap` distribution as well.