### PR TITLE
Terminusdb bin

### DIFF
--- a/terminusdb
+++ b/terminusdb
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+$SCRIPT_DIR/terminusdb-container cli "${@:1}"

--- a/terminusdb-container
+++ b/terminusdb-container
@@ -265,7 +265,7 @@ if [[ -n "$1" ]]; then
         # shellcheck disable=SC2124
         TERMINUSDB_RUN_CMD="${@:2}"
       fi
-        _cli || printf "\nError on executing the CLI command, did you forget to run the container first with the run command?"
+        _cli || printf "\nError on executing the CLI command, did you forget to run the container first with the run command? Run: ./terminusdb-container run"
     ;;
     "stop")
       _check_if_docker_is_in_path


### PR DESCRIPTION
It is useful to have a script called `terminusdb` for people following the tutorials, as we otherwise have to say that people should be running `terminusdb-container cli` all the time instead.

The script simply calls `terminusdb-container cli`.