### PR TITLE
terminusdb-container: use variable for 'docker' command

### DIFF
--- a/terminusdb-container
+++ b/terminusdb-container
@@ -289,7 +289,7 @@ fi
 }
 
 _upgrade() {
-    docker run \
+    $TERMINUSDB_QUICKSTART_DOCKER run \
            -e TERMINUSDB_QUICKSTART_STORAGE="$TERMINUSDB_QUICKSTART_STORAGE_VOLUME" \
            -v "$TERMINUSDB_QUICKSTART_STORAGE:$TERMINUSDB_QUICKSTART_STORAGE_VOLUME:rw" \
            terminusdb/terminusdb-upgrade


### PR DESCRIPTION
Use variable for `docker` command so the `upgrade` command works with other clients (eg. `podman`).